### PR TITLE
chore: redirect contributions to upstream repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Bazaar Flathub Manifest
+
+Please submit PRs to the development manifest in the upstream repo [here](https://github.com/kolunmi/bazaar/blob/main/build-aux/flatpak/io.github.kolunmi.Bazaar.json) so changes can be better tested.

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-  "require-important-update": true
+  "require-important-update": true,
+  "disable-external-data-checker": true
 }


### PR DESCRIPTION
External-data-checker updates happen in the uptream repo via github actions and when releases are made synced to this repo.